### PR TITLE
Fix LU/LV calculation

### DIFF
--- a/lua/niknaks/modules/sh_bsp_faces.lua
+++ b/lua/niknaks/modules/sh_bsp_faces.lua
@@ -197,6 +197,9 @@ function meta_face:GenerateVertexData()
 		end
 	end
 
+	local luxelW = self.LightmapTextureSizeInLuxels[1] + 1
+	local luxelH = self.LightmapTextureSizeInLuxels[2] + 1
+
 	for i = 0, self.numedges - 1 do
 		local vert = {}
 		local a = self.__map:GetSurfEdgesIndex( self.firstedge + i )
@@ -210,8 +213,8 @@ function meta_face:GenerateVertexData()
 		vert.u = ( tv[0][0] * a.x + tv[0][1] * a.y + tv[0][2] * a.z + tv[0][3] ) / mat_w
 		vert.v = ( tv[1][0] * a.x + tv[1][1] * a.y + tv[1][2] * a.z + tv[1][3] ) / mat_h
 
-		vert.lu = self.LightmapTextureMinsInLuxels[1] - ( lv[0][0] * a.x + lv[0][1] * a.y + lv[0][2] * a.z + lv[0][3] )
-		vert.lv = self.LightmapTextureMinsInLuxels[2] - ( lv[1][0] * a.x + lv[1][1] * a.y + lv[1][2] * a.z + lv[1][3] )
+		vert.lu = ( ( lv[0][0] * a.x + lv[0][1] * a.y + lv[0][2] * a.z + lv[0][3] ) - self.LightmapTextureMinsInLuxels[1] ) / luxelW
+		vert.lv = ( ( lv[1][0] * a.x + lv[1][1] * a.y + lv[1][2] * a.z + lv[1][3] ) - self.LightmapTextureMinsInLuxels[2] ) / luxelH
 
 		vert.userdata = { 0, 0, 0, 0 } -- Todo: Calculate this?
 


### PR DESCRIPTION
Pasting my explanation from Discord:

---

```lua
vert.lu = self.LightmapTextureMinsInLuxels[1] - ( lv[0][0] * a.x + lv[0][1] * a.y + lv[0][2] * a.z + lv[0][3] )
vert.lv = self.LightmapTextureMinsInLuxels[2] - ( lv[1][0] * a.x + lv[1][1] * a.y + lv[1][2] * a.z + lv[1][3] )
```
this is what's in there right now
the trouble here is that this will always produce a negative value for both

instead, I think it makes more sense for it to be like:
```lua
vert.lu =  ( lv[0][0] * a.x + lv[0][1] * a.y + lv[0][2] * a.z + lv[0][3] ) - self.LightmapTextureMinsInLuxels[1]
vert.lv =  ( lv[1][0] * a.x + lv[1][1] * a.y + lv[1][2] * a.z + lv[1][3] ) - self.LightmapTextureMinsInLuxels[2]
```

now lu/lv are positive, which i think makes more sense. i think this is also supported by the docs:
> The lightmapVecs float array performs a similar mapping of the lightmap samples of the texture onto the world. It is the same formula but with lightmapVecs instead of textureVecs, **and then subtracting the [0] and [1] values of LightmapTextureMinsInLuxels for u and v respectively**. LightmapTextureMinsInLuxels is referenced in dface_t;

then, the next issue is that lu/lv aren't between 0-1 like u/v are, which seemed odd - in the docs they say:
> Furthermore, after calculating (u, v), to convert them to texture coordinates which you would send to your graphics card, divide u and v by the width and height of the texture respectively.

now I think you already did this for u/v, but not for lu/lv - so if we divide lu/lv by the Luxel size, we end up with positive numbers between 0 and 1:
```lua
local luxelW = self.LightmapTextureSizeInLuxels[1] + 1
local luxelH = self.LightmapTextureSizeInLuxels[2] + 1

vert.lu = ( ( lv[0][0] * a.x + lv[0][1] * a.y + lv[0][2] * a.z + lv[0][3] ) - self.LightmapTextureMinsInLuxels[1] ) / luxelW
vert.lv = ( ( lv[1][0] * a.x + lv[1][1] * a.y + lv[1][2] * a.z + lv[1][3] ) - self.LightmapTextureMinsInLuxels[2] ) / luxelH
```