### PR TITLE
Fixes for face BuildMesh and DebugRender, Add property for getting back planes

### DIFF
--- a/lua/niknaks/modules/sh_bsp_faces.lua
+++ b/lua/niknaks/modules/sh_bsp_faces.lua
@@ -745,7 +745,7 @@ if CLIENT then
 		render.SetMaterial( iMaterial or  self:GetMaterial() )
 		local verts = self:GenerateVertexTriangleData()
 		if not verts then return end
-		mesh.Begin(MATERIAL_TRIANGLES, #verts / 3 ) -- Begin writing to the dynamic mesh
+		mesh.Begin( MATERIAL_TRIANGLES, #verts / 3 ) -- Begin writing to the dynamic mesh
 		for i = 1, #verts do
 			local vert = verts[i]
 			mesh.Normal( vert.normal )

--- a/lua/niknaks/modules/sh_bsp_faces.lua
+++ b/lua/niknaks/modules/sh_bsp_faces.lua
@@ -741,15 +741,21 @@ if CLIENT then
 	end
 
 	--- Generates a mesh for the face and renders it.
-	function meta_face:DebugRender( iMaterial)	
+	function meta_face:DebugRender( iMaterial )
 		render.SetMaterial( iMaterial or  self:GetMaterial() )
 		local verts = self:GenerateVertexTriangleData()
 		if not verts then return end
-		mesh.Begin(nil, MATERIAL_TRIANGLES, #verts / 3 ) -- Begin writing to the dynamic mesh
+		mesh.Begin(MATERIAL_TRIANGLES, #verts / 3 ) -- Begin writing to the dynamic mesh
 		for i = 1, #verts do
-			mesh.Position( verts[i].pos ) -- Set the position
-			mesh.TexCoord( 0, verts[i].u, verts[i].v ) -- Set the texture UV coordinates
-			mesh.TexCoord( 1, verts[i].u1, verts[i].v1 ) -- Set the light UV coordinates
+			local vert = verts[i]
+			mesh.Normal( vert.normal )
+			mesh.Position( vert.pos ) -- Set the position
+			mesh.Color( 255, 255, 255, 255 )
+			mesh.TexCoord( 0, vert.u, vert.v ) -- Set the texture UV coordinates
+			mesh.TexCoord( 1, vert.u1, vert.v1 ) -- Set the lightmap UV coordinates
+			mesh.TexCoord( 2, vert.u1, vert.v1 ) -- Set the lightmap UV coordinates
+			mesh.TangentS( 0, 0, 0 )
+			mesh.TangentT( 0, 0, 0 )
 			mesh.AdvanceVertex() -- Write the vertex
 		end
 		mesh.End() -- Finish writing the mesh and draw it

--- a/lua/niknaks/modules/sh_bsp_faces.lua
+++ b/lua/niknaks/modules/sh_bsp_faces.lua
@@ -697,22 +697,22 @@ if CLIENT then
 			return self._mesh
 		end
 
-		local meshData = self:GenerateVertexTriangleData()
-		if not meshData then return self._mesh end
+		local verts = self:GenerateVertexTriangleData()
+		if not verts then return self._mesh end
 
 		self._mesh = Mesh( self:GetMaterial() )
 
 		-- Vert
-		mesh.Begin( self._mesh, MATERIAL_TRIANGLES, #meshData )
-		for i = 1, #meshData do
-			local vert = meshData[i]
+		mesh.Begin( self._mesh, MATERIAL_TRIANGLES, #verts / 3 )
+		for i = 1, #verts do
+			local vert = verts[i]
 			-- > Mesh
 			mesh.Normal( vert.normal )
 			mesh.Position( vert.pos ) -- Set the position
 			mesh.Color(col.r, col.g, col.b, col.a)
 			mesh.TexCoord( 0, vert.u, vert.v ) -- Set the texture UV coordinates
-			mesh.TexCoord( 1, vert.lu, vert.lv ) -- Set the lightmap UV coordinates
-			mesh.TexCoord( 2, vert.lu, vert.lv  ) -- Set the lightmap UV coordinates
+			mesh.TexCoord( 1, vert.u1, vert.v1 ) -- Set the lightmap UV coordinates
+			mesh.TexCoord( 2, vert.u1, vert.v1 ) -- Set the lightmap UV coordinates
 			--mesh.TexCoord( 2, self.LightmapTextureSizeInLuxels[1], self.LightmapTextureSizeInLuxels[2] ) -- Set the texture UV coordinates
 			--mesh.TexCoord( 2, self.LightmapTextureMinsInLuxels[1], self.LightmapTextureMinsInLuxels[2] ) -- Set the texture UV coordinates
 			mesh.AdvanceVertex()

--- a/lua/niknaks/modules/sh_bsp_module.lua
+++ b/lua/niknaks/modules/sh_bsp_module.lua
@@ -686,8 +686,9 @@ do
 
 	--- @class BSPPlane
 	--- @field normal Vector # Normal vector
-	--- @field dist number # distance form origin
-	--- @field type number # plane axis indentifier
+	--- @field dist number # Distance from origin
+	--- @field type number # Plane axis identifier
+	--- @field back BSPPlane # Back plane
 	local planeMeta = {}
 	planeMeta.__index = planeMeta
 	NikNaks.__metatables["BSP Plane"] = planeMeta
@@ -710,14 +711,14 @@ do
 			--- @class BSPPlane
 			local t = {}
 			t.normal = data:ReadVector() -- Normal vector
-			t.dist = data:ReadFloat() -- distance form origin
-			t.type = data:ReadLong() -- plane axis indentifier
+			t.dist = data:ReadFloat() -- Distance from origin
+			t.type = data:ReadLong() -- Plane axis identifier
 			setmetatable( t, planeMeta )
 			self._plane[i] = t
 		end
 
 		for i, t in pairs( self._plane ) do
-			t.back = self._plane[ bit.bxor( i, 1 ) ]
+			t.back = self._plane[ bit.bxor( i, 1 ) ] -- Back plane
 		end
 
 		self:ClearLump( 1 )

--- a/lua/niknaks/modules/sh_bsp_module.lua
+++ b/lua/niknaks/modules/sh_bsp_module.lua
@@ -712,8 +712,12 @@ do
 			t.normal = data:ReadVector() -- Normal vector
 			t.dist = data:ReadFloat() -- distance form origin
 			t.type = data:ReadLong() -- plane axis indentifier
-			setmetatable(t, planeMeta)
+			setmetatable( t, planeMeta )
 			self._plane[i] = t
+		end
+
+		for i, t in pairs( self._plane ) do
+			t.back = self._plane[ bit.bxor( i, 1 ) ]
 		end
 
 		self:ClearLump( 1 )


### PR DESCRIPTION
Fixes `BSPFaceObject:BuildMesh` using `lu` and `lv` instead of `u1` and `v1` for lightmap tex coord.
Fixes `BSPFaceObject:DebugRender` passing `nil` as the first argument to `mesh.Begin` and not setting some mesh values.
Adds `back` property to `BSPPlane` that equals its back plane object. (in Source it's done by indexing `planenum^1` in the mapplanes array)