### PR TITLE
Added alpha blending color to displacements mesh data

### DIFF
--- a/lua/niknaks/modules/sh_bsp_faces.lua
+++ b/lua/niknaks/modules/sh_bsp_faces.lua
@@ -512,7 +512,8 @@ local function GetDisplacementVertexs(self, faceVertexData )
 				v = textureUV.y,
 				u1 = lightmapUV.x,
 				v1 = lightmapUV.y,
-				userdata = { 0, 0, 0, 0 }
+				userdata = { 0, 0, 0, 0 },
+				color = Color( 0, 0, 0, vertex.alpha )
 			} )
 
 			index = index + 1


### PR DESCRIPTION
Added `vertex.alpha` to `vertices` table as key `color` in `GetDisplacementVertexs` function.